### PR TITLE
This fixed #35 Artifact file path use Unix style file separator 

### DIFF
--- a/agent/artifacts.go
+++ b/agent/artifacts.go
@@ -257,7 +257,7 @@ func (u *Artifacts) zipSource(source string, dest string) (string, string, error
 			// source is a directory, find relative path
 			// from source and attach to dest path
 			rel := path[len(source):]
-			if strings.HasPrefix(rel, "/") {
+			if strings.HasPrefix(rel, string(os.PathSeparator)) {
 				rel = rel[1:]
 			}
 			if dest == "" {


### PR DESCRIPTION
Artifact file path use Unix style file separator Windows
