### PR TITLE
#31 fixup, always use unix path as key in md5 checksums on fetch

### DIFF
--- a/agent/artifacts.go
+++ b/agent/artifacts.go
@@ -145,6 +145,8 @@ func (u *Artifacts) VerifyChecksumFile(srcFname, fname, checksumFname string) er
 		return err
 	}
 	properties := ParseChecksum(string(checksum))
+	// Convert path used as key name in properties, because md5.checksum always has unix / slashes
+	srcFname=filename.ToSlash(srcFname)
 	if properties[srcFname] == "" {
 		return Err("[WARN] The md5checksum value of the artifact [%v] was not found on the server. Hence, Go could not verify the integrity of its contents.", srcFname)
 	} else if properties[srcFname] != md5 {


### PR DESCRIPTION
@barrowkwan your previous fix for #31 only fixed paths uploaded to server, so that artifacts have correct paths and m5.checksum is converted to linux. 
But when I tried to **fetch artifacts on windows**, I got this error:

```
01:31:02.922 [go] Fetching artifact [build/bin] from [libstc-windows.ci/965e3f6a/build/latest/debug]
01:31:04.282 ERROR: [WARN] The md5checksum value of the artifact [build/bin/Debug\libstc_test.exe] was not found on the server. Hence, Go could not verify the integrity of its contents.
```

Obviously, this is agent using `build/bin/Debug\libstc_test.exe` as key, which should be `build/bin/Debug/libstc_test.exe` as it exists in md5.checksum file.

This is fix for that case. I compiled from source and verified it works on windows.
