### PR TITLE
Adding -in and -nin flags to CommandTest

### DIFF
--- a/agent/test.go
+++ b/agent/test.go
@@ -26,7 +26,7 @@ import (
 func CommandTest(s *BuildSession, cmd *protocol.BuildCommand) error {
 	flag := cmd.Args["flag"]
 
-	if flag == "-eq" || flag == "-neq" {
+	if flag == "-eq" || flag == "-neq" || flag == "-in" || flag == "-nin" {
 		output, err := s.processTestCommand(cmd.SubCommands[0])
 		if err != nil {
 			s.debugLog("test -eq exec command error: %v", err)
@@ -38,11 +38,15 @@ func CommandTest(s *BuildSession, cmd *protocol.BuildCommand) error {
 			if expected != actual {
 				return Err("expected '%v', but was '%v'", expected, actual)
 			}
-		} else {
+		} else if flag == "-neq" {
 			if expected == actual {
 				return Err("expected different with '%v'", expected)
 			}
-		}
+		} else if flag == "-in" {
+                  return strings.contains(expected, actual);
+                } else if flag == "-nin" {
+                  return !strings.contains(expected, actual);
+                }
 		return nil
 	}
 


### PR DESCRIPTION
* -in looks to see if a string is in the output of a command
* -nin looks to verify that a string is not in the output of a command

@barrowkwan 
These changes need to be made after https://github.com/gocd/gocd/pull/3374 is merged into the main gocd repository. 

I'm unsure if there are tests I need to update?? I'm not familiar with golang, and I didn't see any files that looked like tests